### PR TITLE
fix(smaug): don't send repeated emails plus nits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /target
 
-config.toml
+config-bitcoin.toml
+config-signet.toml
+config-testnet3.toml
+config-testnet4.toml
+config-regtest.toml
 
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Smaug
+# smaug 🐉
 
 <p align="center">
   <img src="smaug.jpg" width="50%" alt="Smaug">

--- a/justfile
+++ b/justfile
@@ -8,6 +8,7 @@ _default:
 # Check code: formatting, compilation and linting
 check:
    cargo +nightly fmt --all -- --check
+   cargo +nightly clippy -- -D warnings
    cargo check
 
 # Format code

--- a/src/email.rs
+++ b/src/email.rs
@@ -21,15 +21,15 @@ use crate::smaug::Event;
 pub enum EmailError {
     /// TLS error.
     #[error(transparent)]
-    TlsError(#[from] smtp::Error),
+    Tls(#[from] smtp::Error),
 
     /// Email address parsing error.
     #[error(transparent)]
-    EmailAddressParsingError(#[from] AddressError),
+    EmailAddressParsing(#[from] AddressError),
 
     /// Email building error.
     #[error(transparent)]
-    EmailBuildError(#[from] LettreError),
+    EmailBuild(#[from] LettreError),
 }
 
 /// Create an email message from an [`Event`] to every address in `recipient_emails`.

--- a/src/email.rs
+++ b/src/email.rs
@@ -53,7 +53,7 @@ pub(crate) fn build_messages(config: &Config, event: &Event) -> Result<Vec<Messa
             let num_addresses = addresses.len();
 
             let subject: String = match num_addresses {
-                1 => format!("You're now subscribed to 1 address"),
+                1 => String::from("You're now subscribed to 1 address"),
                 _ => format!("You're now subscribed to {} addresses", num_addresses),
             };
 
@@ -120,14 +120,13 @@ pub(crate) fn build_messages(config: &Config, event: &Event) -> Result<Vec<Messa
     let messages: Vec<Message> = recipient_mailboxes
         .iter()
         .map(|mailbox| {
-            let message = Message::builder()
+            Message::builder()
                 .from(sender_mailbox.clone())
                 .to(mailbox.clone())
                 .subject(subject.clone())
                 .header(ContentType::TEXT_PLAIN)
                 .body(body.clone())
-                .unwrap();
-            message
+                .unwrap()
         })
         .collect();
 
@@ -146,7 +145,7 @@ pub(crate) fn send_messages(config: &Config, messages: &Vec<Message>) -> Result<
 
     debug!("Sending {} emails...", messages.len());
     for message in messages {
-        mailer.send(&message)?;
+        mailer.send(message)?;
         if let Some(recipient) = message.envelope().to().first() {
             info!("Sent email to {}", recipient);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ pub(crate) struct Config {
 }
 
 fn parse_config(config_path: &str) -> Config {
-    let config_str = match fs::read_to_string(&config_path) {
+    let config_str = match fs::read_to_string(config_path) {
         Ok(config_str) => config_str,
         Err(_) => {
             error!("Failed to open `{config_path}`. Does the file exist?");
@@ -84,7 +84,7 @@ fn parse_config(config_path: &str) -> Config {
 
 /// Check that the addresses and network provided are a match.
 pub(crate) fn check_addresses(
-    addresses: &Vec<Address<NetworkUnchecked>>,
+    addresses: &[Address<NetworkUnchecked>],
     network: &Network,
 ) -> Result<Vec<Address>, SmaugError> {
     addresses
@@ -92,7 +92,7 @@ pub(crate) fn check_addresses(
         .map(|addr| {
             addr.clone()
                 .require_network(network.to_owned())
-                .map_err(|e| SmaugError::NetworkMismatch(e))
+                .map_err(SmaugError::NetworkMismatch)
         })
         .collect()
 }
@@ -117,10 +117,14 @@ fn main() -> Result<(), SmaugError> {
         .parse_default_env()
         .init();
 
+    // Parse the `config`/`c` CLI argument into [`Cli`].
     let args: Cli = argh::from_env();
-    let config = parse_config(&args.config);
 
-    let _ = smaug(&config)?;
+    // Parse the TOML config file into [`Config`].
+    let config: Config = parse_config(&args.config);
+
+    // Run the "watchdragon".
+    smaug(&config)?;
 
     Ok(())
 }

--- a/src/smaug.rs
+++ b/src/smaug.rs
@@ -175,7 +175,7 @@ pub(crate) fn smaug(config: &Config) -> Result<(), SmaugError> {
         info!("Fetching state at height {}...", current_chain_tip);
 
         // Fetch the current state from Esplora.
-        let mut current_state = UtxoDB::new();
+        current_state = UtxoDB::new();
         for address in &addresses {
             let utxos = esplora.get_address_utxos(&address)?;
             current_state.insert(address.clone(), utxos);

--- a/src/smaug.rs
+++ b/src/smaug.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, thread, time::Duration};
+use std::{collections::HashMap, process, thread, time::Duration};
 
 use bitcoin::{
     Network,
@@ -14,19 +14,19 @@ use crate::check_addresses;
 use crate::email::{EmailError, build_messages, send_messages};
 
 /// The amount of seconds to sleep for between checks.
-pub(crate) const SLEEP_SECS: u64 = 10;
+pub(crate) const POLLING_PERIOD_SEC: u64 = 10;
 
 /// A [`HashMap`] that maps an address to multiple [`Utxo`]s.
 pub(crate) type UtxoDB = HashMap<Address<NetworkChecked>, Vec<Utxo>>;
 
-/// Bitcoin Mempool.space Esplora API base URL.
+/// Default Esplora API base URLs.
 pub(crate) const BITCOIN_ESPLORA: &str = "https://mempool.space/api";
 /// Signet Mempool.space Esplora API base URL.
 pub(crate) const SIGNET_ESPLORA: &str = "https://mempool.space/signet/api";
 /// Testnet4 Mempool.space Esplora API base URL.
 pub(crate) const TESTNET4_ESPLORA: &str = "https://mempool.space/testnet4/api";
 
-/// Parameters of an [`Event`].
+/// Parameters of an [`Event`] of kind `Subscription` or `Deposit`.
 #[derive(Clone, Debug)]
 pub(crate) struct EventParams {
     /// What address this event refers to.
@@ -37,7 +37,7 @@ pub(crate) struct EventParams {
     pub(crate) height: u32,
 }
 
-/// An address-related event.
+/// An [`Event`] about a Bitcoin address.
 #[derive(Clone, Debug)]
 pub(crate) enum Event {
     /// Subscription to a set of addresses.
@@ -50,7 +50,7 @@ pub(crate) enum Event {
 
 #[derive(Debug, Error)]
 pub(crate) enum SmaugError {
-    /// Error parsing an [Address<NetworkUnchecked>] to an [Address<NetworkChecked>].
+    /// Error parsing an [`Address<NetworkUnchecked>`] to an [`Address<NetworkChecked>`].
     #[error(transparent)]
     NetworkMismatch(#[from] bitcoin::address::ParseError),
 
@@ -66,7 +66,7 @@ pub(crate) enum SmaugError {
 /// Compute the difference in the set of UTXOs locked to an address.
 ///
 /// Returns two vectors: deposited UTXOs and withdrawn UTXOs.
-pub(crate) fn compute_diff(current_state: &Vec<Utxo>, last_state: &Vec<Utxo>) -> (Vec<Utxo>, Vec<Utxo>) {
+pub(crate) fn compute_diff(current_state: &[Utxo], last_state: &[Utxo]) -> (Vec<Utxo>, Vec<Utxo>) {
     let deposited: Vec<Utxo> = current_state
         .iter()
         .filter(|utxo| !last_state.contains(utxo))
@@ -90,12 +90,12 @@ pub(crate) fn handle_event(config: &Config, event: &Event) -> Result<(), SmaugEr
     // iff `notify_subscriptions` and `notify_deposits` are set.
     match event {
         Event::Subscription(_) => {
-            if config.notify_deposits == true {
+            if config.notify_subscriptions {
                 send_messages(config, &messages)?;
             }
         }
         Event::Deposit(_) => {
-            if config.notify_deposits == true {
+            if config.notify_deposits {
                 send_messages(config, &messages)?;
             }
         }
@@ -105,27 +105,30 @@ pub(crate) fn handle_event(config: &Config, event: &Event) -> Result<(), SmaugEr
     Ok(())
 }
 
-/// Long-poll the Esplora API, compute diffs of the address states and notify the recipients.
+/// Long-poll the Esplora API, compute address state diffs, and notify the recipients if there is a diff.
 pub(crate) fn smaug(config: &Config) -> Result<(), SmaugError> {
     let base_url = match &config.esplora_url {
         Some(url) => {
-            debug!("Using configured Esplora API: {url}");
+            info!("Using configured Esplora API: {url}");
             url
         }
         None => match &config.network {
             Network::Bitcoin => {
-                debug!("Using default Bitcoin Esplora API: {BITCOIN_ESPLORA}");
+                info!("Using default Bitcoin Esplora API: {BITCOIN_ESPLORA}");
                 BITCOIN_ESPLORA
             }
             Network::Signet => {
-                debug!("Using default Signet Esplora API: {SIGNET_ESPLORA}");
+                info!("Using default Signet Esplora API: {SIGNET_ESPLORA}");
                 SIGNET_ESPLORA
             }
             Network::Testnet4 => {
-                debug!("Using default Testnet4 API: {TESTNET4_ESPLORA}");
+                info!("Using default Testnet4 Esplora API: {TESTNET4_ESPLORA}");
                 TESTNET4_ESPLORA
             }
-            _ => unreachable!("Other networks are not supported"),
+            _ => {
+                error!("Other networks are not supported");
+                process::exit(1);
+            }
         },
     };
 
@@ -142,7 +145,7 @@ pub(crate) fn smaug(config: &Config) -> Result<(), SmaugError> {
     let mut current_state = UtxoDB::new();
     for address in &addresses {
         // Fetch the UTXOs currently locked to the address.
-        let utxos = esplora.get_address_utxos(&address)?;
+        let utxos = esplora.get_address_utxos(address)?;
 
         info!("Subscribed to address {} at height {}", address, current_chain_tip);
 
@@ -152,7 +155,7 @@ pub(crate) fn smaug(config: &Config) -> Result<(), SmaugError> {
     debug!("initial_state = {:#?}", current_state);
 
     // Send subscription email iff `config.notify_subscriptions` is set.
-    if config.notify_subscriptions == true {
+    if config.notify_subscriptions {
         let event = Event::Subscription(addresses.clone());
         handle_event(config, &event)?;
     }
@@ -165,7 +168,7 @@ pub(crate) fn smaug(config: &Config) -> Result<(), SmaugError> {
 
         // Check if the `current_chain_tip` is superior than `last_chain_tip`. If not, skip.
         if current_chain_tip <= last_chain_tip {
-            thread::sleep(Duration::from_secs(SLEEP_SECS));
+            thread::sleep(Duration::from_secs(POLLING_PERIOD_SEC));
             continue;
         }
 
@@ -177,7 +180,7 @@ pub(crate) fn smaug(config: &Config) -> Result<(), SmaugError> {
         // Fetch the current state from Esplora.
         current_state = UtxoDB::new();
         for address in &addresses {
-            let utxos = esplora.get_address_utxos(&address)?;
+            let utxos = esplora.get_address_utxos(address)?;
             current_state.insert(address.clone(), utxos);
         }
 
@@ -187,6 +190,7 @@ pub(crate) fn smaug(config: &Config) -> Result<(), SmaugError> {
             let (deposited, withdrawn) =
                 compute_diff(current_state.get(address).unwrap(), last_state.get(address).unwrap());
 
+            // Create [`Event::Deposit`]s based on the `UtxoDBs` diff between the last and current states.
             for deposit in deposited {
                 let event: Event = Event::Deposit(EventParams {
                     address: address.clone(),
@@ -195,6 +199,8 @@ pub(crate) fn smaug(config: &Config) -> Result<(), SmaugError> {
                 });
                 events.push(event);
             }
+
+            // Create [`Event::Withdrawal`]s based on the `UtxoDBs` diff between the last and current states.
             for withdrawal in withdrawn {
                 let event: Event = Event::Withdrawal(EventParams {
                     address: address.clone(),
@@ -208,12 +214,12 @@ pub(crate) fn smaug(config: &Config) -> Result<(), SmaugError> {
 
         for event in &events {
             match event {
-                Event::Deposit(_) => handle_event(config, &event)?,
-                Event::Withdrawal(_) => handle_event(config, &event)?,
+                Event::Deposit(_) => handle_event(config, event)?,
+                Event::Withdrawal(_) => handle_event(config, event)?,
                 _ => {}
             }
         }
 
-        thread::sleep(Duration::from_secs(SLEEP_SECS));
+        thread::sleep(Duration::from_secs(POLLING_PERIOD_SEC));
     }
 }


### PR DESCRIPTION
Closes #9.

Fixes a bug where withdrawal emails would be sent repeatedly at every new block. It was caused by the `current_state` variable being shadowed by mistake on the event loop.

Also applies some lints and other miscellaneous nits.